### PR TITLE
Fixes use of deprecated function `each`

### DIFF
--- a/src/UseStatements.php
+++ b/src/UseStatements.php
@@ -95,7 +95,8 @@ class UseStatements
 		$namespace = $class = $classLevel = $level = NULL;
 		$res = $uses = [];
 
-		while (list(, $token) = each($tokens)) {
+		while ($token = current($tokens)) {
+            		next($tokens);
 			switch (is_array($token) ? $token[0] : $token) {
 				case T_NAMESPACE:
 					$namespace = ltrim(self::fetch($tokens, [T_STRING, T_NS_SEPARATOR]) . '\\', '\\');


### PR DESCRIPTION
the function `each` is deprecated since PHP 7.2  This pull request fixes that by replacing `each` with `current` and `next`